### PR TITLE
replace os.environ['HOME'] with Path.home() for Windows compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 
+from pathlib import Path
 from setuptools import find_packages, setup
 
 # from setuptools.config import read_configuration
@@ -7,8 +8,8 @@ from setuptools import find_packages, setup
 # extras = read_configuration('pyproject.toml')
 
 # create home directory
-if not os.path.isdir(os.path.join(os.environ['HOME'], '.PyThea')):
-    os.mkdir(os.path.join(os.environ['HOME'], '.PyThea'))
+if not os.path.isdir(os.path.join(Path.home(), '.PyThea')):
+    os.mkdir(os.path.join(Path.home(), '.PyThea'))
 
 with open('README_pypi.md', 'r', encoding='utf8') as f:
     long_description = f.read()


### PR DESCRIPTION
On Windows, the pip installation fails because Windows doesn't have a HOME environment variable (at least not always); it uses USERPROFILE instead (as far as I understand), resulting in the pip installation to crash. 

This has been fixed by replacing `os.environ['HOME']` with `Path.home()` (requires `from pathlib import Path`) in setup.py.

Fixes #17 